### PR TITLE
Make addon Ember 2 compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Quick and simple ember & KISSmetrics integration
 
 * `npm install --save-dev ember-kiss-metrics`
 * add `config.kissmetricsKey` to config/environment.js
+* optionally add `kissmetricsForceSSL=true` to config/environment.js to force loading scripts via SSL.  This is required if using Cordova/PhoneGap.
 
 in `routes` and `controller` you will have `_kmq.push` available
 

--- a/app/initializers/ember-kiss-metrics.js
+++ b/app/initializers/ember-kiss-metrics.js
@@ -1,8 +1,9 @@
 export function initialize() {
-  let application = arguments[1] || arguments[0];
-  if (arguments[1]) {
+  let application = arguments[0];
+  if (arguments.length === 2) {
     //for ember 1.x
     const container = arguments[0];
+    application =  arguments[1];
     container.options('kmq:main'); 
   }
   application.inject('controller', '_kmq', 'kmq:main');

--- a/app/initializers/ember-kiss-metrics.js
+++ b/app/initializers/ember-kiss-metrics.js
@@ -1,4 +1,10 @@
-export function initialize(application) {
+export function initialize() {
+  let application = arguments[1] || arguments[0];
+  if (arguments[1]) {
+    //for ember 1.x
+    const container = arguments[0];
+    container.options('kmq:main'); 
+  }
   application.inject('controller', '_kmq', 'kmq:main');
   application.inject('route',      '_kmq', 'kmq:main');
 };

--- a/app/initializers/ember-kiss-metrics.js
+++ b/app/initializers/ember-kiss-metrics.js
@@ -1,5 +1,4 @@
-export function initialize(container, application) {
-  container.options('kmq:main');
+export function initialize(application) {
   application.inject('controller', '_kmq', 'kmq:main');
   application.inject('route',      '_kmq', 'kmq:main');
 };

--- a/app/kmqs/main.js
+++ b/app/kmqs/main.js
@@ -16,8 +16,13 @@ function load(u) {
 }
 
 if (config.kissmetricsKey) {
-  load('https://i.kissmetrics.com/i.js');
-  load('https://doug1izaerwt3.cloudfront.net/' + config.kissmetricsKey + '.1.js')
+  let pathPrefix = '//';
+  if (config.kissmetricsForceSSL) {
+    pathPrefix = 'https://';
+  }
+  load(pathPrefix + 'i.kissmetrics.com/i.js');
+  load(pathPrefix + 'doug1izaerwt3.cloudfront.net/' + config.kissmetricsKey + '.1.js')
+
 } else {
   throw new TypeError('Missing config/environment entry `config.kissmetricsKey`');
 }

--- a/app/kmqs/main.js
+++ b/app/kmqs/main.js
@@ -16,8 +16,8 @@ function load(u) {
 }
 
 if (config.kissmetricsKey) {
-  load('//i.kissmetrics.com/i.js');
-  load('//doug1izaerwt3.cloudfront.net/' + config.kissmetricsKey + '.1.js')
+  load('https://i.kissmetrics.com/i.js');
+  load('https://doug1izaerwt3.cloudfront.net/' + config.kissmetricsKey + '.1.js')
 } else {
   throw new TypeError('Missing config/environment entry `config.kissmetricsKey`');
 }


### PR DESCRIPTION
This just updates the container injection to be 1 or 2 compliant and forces the use of https on the calls.
