### PR TITLE
Fastboot compatibility and fix deprecation

### DIFF
--- a/app/initializers/ember-kiss-metrics.js
+++ b/app/initializers/ember-kiss-metrics.js
@@ -1,13 +1,16 @@
 export function initialize() {
-  let application = arguments[0];
-  if (arguments.length === 2) {
-    //for ember 1.x
-    const container = arguments[0];
-    application =  arguments[1];
-    container.options('kmq:main'); 
+  if (typeof FastBoot === 'undefined') {
+    // only execute this in browser
+    let application = arguments[0];
+    if (arguments.length === 2) {
+      //for ember 1.x
+      const container = arguments[0];
+      application =  arguments[1];
+      container.options('kmq:main');
+    }
+    application.inject('controller', '_kmq', 'kmq:main');
+    application.inject('route',      '_kmq', 'kmq:main');
   }
-  application.inject('controller', '_kmq', 'kmq:main');
-  application.inject('route',      '_kmq', 'kmq:main');
 };
 
 export default {

--- a/package.json
+++ b/package.json
@@ -35,5 +35,7 @@
   "ember-addon": {
     "configPath": "tests/dummy/config"
   },
-  "dependencies": {}
+  "dependencies": {
+    "ember-cli-babel": "^6.0.0"
+  }
 }


### PR DESCRIPTION
Added Fastboot compatibility to the initializer.  Also added babel to the dependencies to stop the deprecation warning at build time.

It seems this library is rather out of date and could use an update to a more recent ember-cli.  But these temp fixes do seem to be working fine for us.